### PR TITLE
Moved the `get_all_pod_templates/get_generable_templates` logic outside the `DocumentGeneratorLinksViewlet`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 - Fix test `test_get_file_is_unrestricted` by removing permission `View`
   to every roles.
   [gbastien]
+- Moved the `get_all_pod_templates/get_generable_templates` logic outside the
+  `DocumentGeneratorLinksViewlet` so it is easier to override.
+  It is now an `IGenerablePODTemplates` adapter.
+  [gbastien]
 
 3.9 (2019-10-14)
 ----------------

--- a/src/collective/documentgenerator/adapters.py
+++ b/src/collective/documentgenerator/adapters.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from collective.documentgenerator.config import VIEWLET_TYPES
+from plone import api
+
+
+class GenerablePODTemplatesAdapter(object):
+    """ """
+    def __init__(self, context):
+        self.context = context
+
+    def get_all_pod_templates(self):
+        catalog = api.portal.get_tool(name='portal_catalog')
+        brains = catalog.unrestrictedSearchResults(portal_type=VIEWLET_TYPES, sort_on='getObjPositionInParent')
+        pod_templates = [self.context.unrestrictedTraverse(brain.getPath()) for brain in brains]
+
+        return pod_templates
+
+    def get_generable_templates(self):
+        pod_templates = self.get_all_pod_templates()
+        generable_templates = [pt for pt in pod_templates if pt.can_be_generated(self.context)]
+
+        return generable_templates

--- a/src/collective/documentgenerator/configure.zcml
+++ b/src/collective/documentgenerator/configure.zcml
@@ -28,4 +28,10 @@
     <include file="profiles.zcml"/>
     <include file="renderer.zcml"/>
 
+    <adapter
+      for="*"
+      provides=".interfaces.IGenerablePODTemplates"
+      factory=".adapters.GenerablePODTemplatesAdapter"/>
+
+
 </configure>

--- a/src/collective/documentgenerator/interfaces.py
+++ b/src/collective/documentgenerator/interfaces.py
@@ -141,6 +141,12 @@ class IDocumentGeneratorSettings(Interface):
     """
 
 
+class IGenerablePODTemplates(Interface):
+    """
+    Marker interface for generable POD templates adapter.
+    """
+
+
 class CyclicMergeTemplatesException(Exception):
     """
     Templates to merge refers to each othert in a cyclic way.

--- a/src/collective/documentgenerator/viewlets/generationlinks.py
+++ b/src/collective/documentgenerator/viewlets/generationlinks.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from ..config import VIEWLET_TYPES
-from plone import api
+from collective.documentgenerator.interfaces import IGenerablePODTemplates
 from plone.app.layout.viewlets import ViewletBase
 from plone.memoize.view import memoize
+from zope.component import getAdapter
 
 
 class DocumentGeneratorLinksViewlet(ViewletBase):
@@ -12,18 +12,10 @@ class DocumentGeneratorLinksViewlet(ViewletBase):
     def available(self):
         return bool(self.get_generable_templates())
 
-    def get_all_pod_templates(self):
-        catalog = api.portal.get_tool(name='portal_catalog')
-        brains = catalog.unrestrictedSearchResults(portal_type=VIEWLET_TYPES, sort_on='getObjPositionInParent')
-        pod_templates = [self.context.unrestrictedTraverse(brain.getPath()) for brain in brains]
-
-        return pod_templates
-
     @memoize
     def get_generable_templates(self):
-        pod_templates = self.get_all_pod_templates()
-        generable_templates = [pt for pt in pod_templates if pt.can_be_generated(self.context)]
-
+        adapter = getAdapter(self.context, IGenerablePODTemplates)
+        generable_templates = adapter.get_generable_templates()
         return generable_templates
 
     def get_generation_view_name(self, template, output_format):


### PR DESCRIPTION
… so it is easier to override. It is now an `IGenerablePODTemplates` adapter.