### PR TITLE
Add `DOCUMENTGENERATOR_LOG_PARAMETERS` environment variable 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.40 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Add `DOCUMENTGENERATOR_LOG_PARAMETERS` environment variable that can be used to log request form parameters with
+  collective.fingerpointing.
+  [mpeeters]
 
 
 3.39 (2023-06-26)

--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,13 @@ Documentation about the search and replace feature is here :
 `docs/search_replace.rst <https://github.com/collective/collective.documentgenerator/tree/master/docs/search_replace.rst>`_
 
 
+**Logging & Debugging**
+-----------------------
+
+You can specify form request that will be logged using collective.fingerpointing by defining environment variable
+`DOCUMENTGENERATOR_LOG_PARAMETERS)` each parameter must be separated by a comma e.g. `param1,param2`
+
+
 Plone versions
 --------------
 

--- a/src/collective/documentgenerator/browser/generation_view.py
+++ b/src/collective/documentgenerator/browser/generation_view.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import mimetypes
+import os
 import unicodedata
 
 import pkg_resources
@@ -75,6 +76,14 @@ class DocumentGenerationView(BrowserView):
                 '/'.join(self.context.getPhysicalPath()),
                 '/'.join(pod_template.getPhysicalPath()),
                 output_format)
+            allowed_parameters = filter(
+                None,
+                os.getenv("DOCUMENTGENERATOR_LOG_PARAMETERS", "").split(",")
+            )
+            if allowed_parameters:
+                for key, value in self.request.form.items():
+                    if key in allowed_parameters:
+                        extras = "{0} {1}={2}".format(extras, key, value)
             log_info(AUDIT_MESSAGE.format(user, ip, action, extras))
 
         doc, doc_name, gen_context = self._generate_doc(pod_template, output_format, **kwargs)


### PR DESCRIPTION
this variable can be used to log request form parameters with collective.fingerpointing