### PR TITLE
[MOD] use libreoffice docker image from harbor

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
             plone: "6.0"
     services:
       libreoffice:
-        image: imiobe/libreoffice:7.3
+        image: harbor.imio.be/library/libreoffice:7.3
         ports:
           - 2002:2002
         volumes:
@@ -73,7 +73,7 @@ jobs:
             plone: "6.0"
     services:
       libreoffice:
-        image: imiobe/libreoffice:7.3
+        image: harbor.imio.be/library/libreoffice:7.3
         ports:
           - 2002:2002
         volumes:

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ startlibreoffice:
  			   --name="oo_server" \
  			   -v /tmp:/tmp \
  			   -v /var/tmp:/var/tmp \
- 			   imiobe/libreoffice:$(lo_version)
+ 			   harbor.imio.be/library/libreoffice:$(lo_version)
 	docker ps
 
 stoplibreoffice:


### PR DESCRIPTION
We don't use anymore dockerhub as container registry at iMio. We are now using [Harbor](https://goharbor.io/).
This PR modifies the libreoffice docker images used by Github Action.