### PR TITLE
MOD-1077: Improved POD context variables to handle Python structures (list, tuple, dict, set)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ Changelog
 
 - Removed `.` at the end of field title `Templates to merge` and field title `Context variables`.
   [gbastien]
+- Improved POD context variables to handle Python structures (list, tuple, dict, set).
+  BREAKING CHANGE: A context variable `1` is given to the template as the
+  integer `1` and no longer as the string `'1'` (same for `1.5` giving a float and `None`
+  giving `None`). Surround such a value with double quotes (`"1"`) to keep it a string.
+  Invalid Python literal values (plain text, `2026-01-01`, ...) are still kept as a string.
+  (MOD-1077)
+  [chris-adam]
 
 4.0 (2025-08-26)
 ----------------

--- a/src/collective/documentgenerator/content/pod_template.py
+++ b/src/collective/documentgenerator/content/pod_template.py
@@ -37,6 +37,7 @@ from zope.interface import Invalid
 from zope.interface import invariant
 from zope.interface import provider
 
+import ast
 import copy
 import logging
 
@@ -327,7 +328,12 @@ class IConfigurablePODTemplate(IPODTemplate):
     form.widget("context_variables", DataGridFieldFactory)
     context_variables = schema.List(
         title=_(u"Context variables"),
-        description=_("These context variables are added to the odt_file context."),
+        description=_(
+            "These context variables are added to the odt_file context. A value that is a valid "
+            "python literal (True, False, None, 1, [1, 2], (1, 2), {'a': 1}, {1, 2}) is converted "
+            "to it, any other value is kept as a string. Surround a value with double quotes to "
+            "keep it as a string."
+        ),
         required=False,
         value_type=DictRow(schema=IContextVariablesRowSchema, required=False),
     )
@@ -498,18 +504,19 @@ class ConfigurablePODTemplate(PODTemplate):
 
     def get_context_variables(self):
         """
-        Returns context_variables as dict
+        Returns context_variables as dict.
+        A value that is a valid python literal (True, False, None, 1, 1.5, [1, 2], (1, 2), {"a": 1}, {1, 2})
+        is converted to it, any other value is kept as a string.
+        Surrounding a value with double quotes keeps it as a string ('"1"' gives "1").
         """
         ret = {}
         for line in self.context_variables or []:
-            # Simple boolean conversion actually implemented
-            # May be improved with ZPublisher.Converters, managing boolean, int, date, string, text, ...
-            # Those last values in a list box with string as default value
             val = line["value"]
-            if val == "True":
-                val = True
-            elif val == "False":
-                val = False
+            if val:
+                try:
+                    val = ast.literal_eval(val)
+                except (SyntaxError, TypeError, ValueError):
+                    pass  # not a python literal, keep the original string
             ret[line["name"]] = val
         return ret
 

--- a/src/collective/documentgenerator/locales/collective.documentgenerator.pot
+++ b/src/collective/documentgenerator/locales/collective.documentgenerator.pot
@@ -473,7 +473,11 @@ msgid "The replacements that will be made."
 msgstr ""
 
 #: ../content/pod_template.py:311
-msgid "These context variables are added to the odt_file context."
+msgid ""
+"These context variables are added to the odt_file context. A value that is a "
+"valid python literal (True, False, None, 1, [1, 2], (1, 2), {'a': 1}, {1, 2}) "
+"is converted to it, any other value is kept as a string. Surround a value "
+"with double quotes to keep it as a string."
 msgstr ""
 
 #: ../browser/check_pod_templates.pt:30

--- a/src/collective/documentgenerator/locales/es/LC_MESSAGES/collective.documentgenerator.po
+++ b/src/collective/documentgenerator/locales/es/LC_MESSAGES/collective.documentgenerator.po
@@ -480,8 +480,17 @@ msgid "The replacements that will be made."
 msgstr ""
 
 #: ../content/pod_template.py:311
-msgid "These context variables are added to the odt_file context."
-msgstr "Esas variables de contexto son añadidas al contexto del odt_file o plantilla Open Document."
+msgid ""
+"These context variables are added to the odt_file context. A value that is a "
+"valid python literal (True, False, None, 1, [1, 2], (1, 2), {'a': 1}, {1, 2}) "
+"is converted to it, any other value is kept as a string. Surround a value "
+"with double quotes to keep it as a string."
+msgstr ""
+"Esas variables de contexto son añadidas al contexto del odt_file o plantilla "
+"Open Document. Un valor que es un literal de python válido (True, False, "
+"None, 1, [1, 2], (1, 2), {'a': 1}, {1, 2}) se convierte en este, cualquier "
+"otro valor se conserva como cadena de texto. Rodee un valor con comillas "
+"dobles para conservarlo como cadena de texto."
 
 #: ../browser/check_pod_templates.pt:30
 msgid "Used object"

--- a/src/collective/documentgenerator/locales/fr/LC_MESSAGES/collective.documentgenerator.po
+++ b/src/collective/documentgenerator/locales/fr/LC_MESSAGES/collective.documentgenerator.po
@@ -474,8 +474,17 @@ msgid "The replacements that will be made."
 msgstr "Les remplacements qui vont être effectués."
 
 #: ../content/pod_template.py:311
-msgid "These context variables are added to the odt_file context."
-msgstr "Ces variables sont ajoutées au contexte passé au modèle odt."
+msgid ""
+"These context variables are added to the odt_file context. A value that is a "
+"valid python literal (True, False, None, 1, [1, 2], (1, 2), {'a': 1}, {1, 2}) "
+"is converted to it, any other value is kept as a string. Surround a value "
+"with double quotes to keep it as a string."
+msgstr ""
+"Ces variables sont ajoutées au contexte passé au modèle odt. Une valeur qui "
+"est un littéral python valide (True, False, None, 1, [1, 2], (1, 2), {'a': "
+"1}, {1, 2}) est convertie en celui-ci, toute autre valeur est conservée comme "
+"chaîne de caractères. Entourez une valeur de guillemets doubles pour la "
+"conserver comme chaîne de caractères."
 
 #: ../browser/check_pod_templates.pt:30
 msgid "Used object"

--- a/src/collective/documentgenerator/tests/test_base_helper_view.py
+++ b/src/collective/documentgenerator/tests/test_base_helper_view.py
@@ -81,7 +81,8 @@ class TestBaseHelperViewMethods(DexterityIntegrationTests):
             template_data, generation_context, "dummy.odt"
         )
         helper_view._set_appy_renderer(renderer)
-        self.assertEqual(helper_view.context_var("dexter", "undefined"), u"1")
+        # "1" is converted to an int
+        self.assertEqual(helper_view.context_var("dexter", "undefined"), 1)
 
     def test_display_phone(self):
         # belgian phone numbers

--- a/src/collective/documentgenerator/tests/test_configurable_pod_template.py
+++ b/src/collective/documentgenerator/tests/test_configurable_pod_template.py
@@ -233,7 +233,56 @@ class TestConfigurablePODTemplateIntegration(ConfigurablePODTemplateIntegrationT
 
     def test_get_context_variables(self):
         self.assertDictEqual(
-            self.test_podtemplate.get_context_variables(), {"details": "1"}
+            self.test_podtemplate.get_context_variables(), {"details": 1}
+        )
+        # every valid python literal is converted to it, sets included on python 3
+        self.test_podtemplate.context_variables = [
+            {"name": u"a_true", "value": u"True"},
+            {"name": u"a_false", "value": u"False"},
+            {"name": u"a_none", "value": u"None"},
+            {"name": u"an_int", "value": u"1"},
+            {"name": u"a_float", "value": u"1.5"},
+            {"name": u"a_list", "value": u"['a', 'b']"},
+            {"name": u"a_tuple", "value": u"('a', 'b')"},
+            {"name": u"a_dict", "value": u"{'a': 1}"},
+            {"name": u"a_set", "value": u"{1, 2}"},
+            {"name": u"empty_set", "value": u"set()"},
+        ]
+        self.assertDictEqual(
+            self.test_podtemplate.get_context_variables(),
+            {
+                u"a_true": True,
+                u"a_false": False,
+                u"a_none": None,
+                u"an_int": 1,
+                u"a_float": 1.5,
+                u"a_list": ["a", "b"],
+                u"a_tuple": ("a", "b"),
+                u"a_dict": {"a": 1},
+                u"a_set": {1, 2},
+                u"empty_set": set(),
+            },
+        )
+        # anything that is not a python literal is kept as a string,
+        # extra double quotes force a literal looking value to stay a string
+        self.test_podtemplate.context_variables = [
+            {"name": u"text", "value": u"hello"},
+            {"name": u"date", "value": u"2026-01-01"},
+            {"name": u"expr", "value": u"1+1"},
+            {"name": u"quoted_int", "value": u'"1"'},
+            {"name": u"empty", "value": u""},
+            {"name": u"nothing", "value": None},
+        ]
+        self.assertDictEqual(
+            self.test_podtemplate.get_context_variables(),
+            {
+                u"text": u"hello",
+                u"date": u"2026-01-01",
+                u"expr": u"1+1",
+                u"quoted_int": u"1",
+                u"empty": u"",
+                u"nothing": None,
+            },
         )
 
     def test_validate_context_variables(self):

--- a/src/collective/documentgenerator/tests/test_generation_view.py
+++ b/src/collective/documentgenerator/tests/test_generation_view.py
@@ -231,7 +231,7 @@ class TestGenerationViewMethods(PODTemplateIntegrationTest):
         self.assertDictEqual(
             view._get_generation_context(hpv, pod_template),
             {
-                "details": "1",
+                "details": 1,
                 "portal": self.portal,
                 "context": hpv.context,
                 "view": hpv,
@@ -395,7 +395,7 @@ class TestGenerationViewMethods(PODTemplateIntegrationTest):
             generation_view.get_generation_context_helper(), pod_template
         )
         self.assertIn("details", gen_context)
-        self.assertEqual(gen_context["details"], "1")
+        self.assertEqual(gen_context["details"], 1)
 
         # the mailing loop view is called on the folder context !
         generation_view = folder.restrictedTraverse(
@@ -431,7 +431,7 @@ class TestGenerationViewMethods(PODTemplateIntegrationTest):
             generation_view.pod_template,
         )
         self.assertIn("details", gen_context)
-        self.assertEqual(gen_context["details"], "1")
+        self.assertEqual(gen_context["details"], 1)
 
     def test_table_column_modifier(self):
         """ """


### PR DESCRIPTION
## Summary

Port of #80 (branch `MOD-1077/context_var_list`, targeting `3.x`) to the Plone 6 line, as asked for
in the review of that pull request.

`ConfigurablePODTemplate.get_context_variables` only converted the strings `"True"` and `"False"`
to booleans, every other context variable reached the template as a string. It now runs each value
through `ast.literal_eval`, so a value that is a valid Python literal is given to the template as
that literal, and anything else is still kept as a string.

The ticket suggested `json.loads`. `ast.literal_eval` was used instead because it is just as safe
(literals only, no calls, no name lookups) while `json.loads` cannot express a `tuple`, rejects
`True`/`False` (JSON wants lowercase) and would force template authors to write double-quoted JSON
strings instead of the Python syntax they already use in POD templates.

**Beware, this is a behaviour change for existing templates:** a numeric value like `1` is now given
to the template as an int and no longer as the string `"1"`, so a template comparing
`context_var("details") == "1"` stops matching. Surround such a value with double quotes (`"1"`) in
the context variables grid to keep it a string. Values that are not Python literals (plain text,
dates like `2026-01-01`, ...) are unaffected.

## Difference with the 3.x version

On Python 3, `ast.literal_eval` also handles set literals, so `{1, 2}` gives a real set and `set()`
gives an empty set. On Python 2.7 it refuses both and they stay strings. This is asserted in
`test_get_context_variables`, which therefore differs from the assertions on the `3.x` branch.
No extra code was added to force one behaviour or the other: each Python version does what it does.

Converted here: `True`, `False`, `None`, `1`, `1.5`, `[1, 2]`, `(1, 2)`, `{"a": 1}`, `{1, 2}`,
`set()`.

The field description was updated accordingly and the `.pot` / `fr` / `es` catalogs were updated by
hand for the new msgid.

## Ticket

MOD-1077 — https://support-imio.atlassian.net/browse/MOD-1077

## Test results

Run locally with `bin/buildout -c test-6.0.cfg` on Python 3.9.22, `bin/test --test='!robot'`:

- 174 tests, 170 passing.
- 4 pre-existing failures, unrelated to this branch: `test__update_template_styles`,
  `test_mailing_loop_persistent_document_generation`,
  `test_podtemplate_is_still_functional_after_search_replace`, `test_update_templates`. The same 4
  fail identically on unmodified `master` (063668e), so they come from the local environment.
- The three tests touched by this branch (`test_get_context_variables`, `test_context_var`,
  `test__get_generation_context`) pass: 3 tests, 0 failures, 0 errors.

Note for anyone building this locally: the default `buildout.cfg` does not carry the namespace
compatibility pins, so a build made with it cannot even import `collective.z3cform` or `z3c.table`.
`test-6.0.cfg` must be used, which is what the CI workflow does.

## Pre-PR checks

- [x] CHANGES up to date
- [x] Tests exist for new code
- [x] Diff matches ticket
- [x] No debug leftovers
- [x] No stray files / secrets
- [x] Profile / version bumps (n/a: no GenericSetup profile touched, no migration needed)
- [x] Commits reference ticket / mergeable

## Commits

```
031d50b MOD-1077: Improved POD context variables to handle Python structures (list, tuple, dict, set)
```
